### PR TITLE
Converted to VS2017 and added NetCore support

### DIFF
--- a/src/R7InsightCore/IAsyncLoggerConfig.cs
+++ b/src/R7InsightCore/IAsyncLoggerConfig.cs
@@ -1,0 +1,58 @@
+﻿namespace InsightCore.Net
+{
+    /// <summary>
+    /// Logentries Asynchronous Logger configuration parameters
+    /// </summary>
+    public interface IAsyncLoggerConfig
+    {
+        /// <summary>
+        /// GUID for Token-based input (LOGENTRIES_TOKEN), recommended logging method
+        /// </summary>
+        string Token { get; set; }
+
+        /// <summary>
+        ///  Sets the debug flag. Will print error messages to System.Diagnostics.Trace
+        /// </summary>
+        bool Debug { get; set; }
+
+        /// <summary>
+        /// Set to true to use SSL (Token-based or HTTP PUT Logging)
+        /// </summary>
+        bool UseSsl { get; set; }
+
+        /// <summary>
+        /// Set to true to use custom DataHub instance instead of Logentries service.
+        /// </summary>
+        bool IsUsingDataHub { get; set; }
+
+        /// <summary>
+        /// DataHub server address
+        /// </summary>
+        string DataHubAddress { get; set; }
+
+        /// <summary>
+        /// DataHub server port
+        /// </summary>
+        int DataHubPort { get; set; }
+
+        /// <summary>
+        /// Set to true to send HostName alongside with the log message
+        /// </summary>
+        bool LogHostname { get; set; }
+
+        /// <summary>
+        /// User-defined host name. If empty the library will try to obtain it automatically
+        /// </summary>
+        string HostName { get; set; }
+
+        /// <summary>
+        /// Log ID
+        /// </summary>
+        string LogID { get; set; }
+
+        /// <summary>
+        /// Mandatory region option, e.g: us, eu
+        /// </summary>
+        string Region { get; set; }
+    }
+}

--- a/src/R7InsightCore/InsightClient.cs
+++ b/src/R7InsightCore/InsightClient.cs
@@ -22,7 +22,6 @@ namespace InsightCore.Net
         // defined server on defined port.
         public InsightClient(bool useSsl, bool useDataHub, String serverAddr, int port, String region)
         {
-
             // Override port number and server address to send logs to DataHub instance.
             if (useDataHub)
             {
@@ -39,7 +38,7 @@ namespace InsightCore.Net
                 else
                     TcpPort = LeSecurePort;
 
-                ServerAddr = String.Format(LeDataUrl, region); // By default m_ServerAddr points to api.logentries.com if useDataHub is not set to true.
+                ServerAddr = String.Format(LeDataUrl, region);
             }
         }
 

--- a/src/R7InsightCore/InsightClient.cs
+++ b/src/R7InsightCore/InsightClient.cs
@@ -1,11 +1,8 @@
 using System;
 using System.IO;
-using System.Linq;
 using System.Net.Security;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 
 namespace InsightCore.Net
 {
@@ -14,7 +11,7 @@ namespace InsightCore.Net
         // Logentries API server address. 
         protected const String LeDataUrl = "{0}.data.logs.insight.rapid7.com";
 
-        // Port number for logging on Logentries DATA server. 
+        // Port number for logging on Logentries DATA server.
         protected const int LeUnsecurePort = 80;
 
         // Port number for SSL logging on Logentries DATA server. 
@@ -25,33 +22,33 @@ namespace InsightCore.Net
         // defined server on defined port.
         public InsightClient(bool useSsl, bool useDataHub, String serverAddr, int port, String region)
         {
-           
+
             // Override port number and server address to send logs to DataHub instance.
             if (useDataHub)
             {
                 m_UseSsl = false; // DataHub does not support receiving log messages over SSL for now.
-                m_TcpPort = port;
-                m_ServerAddr = serverAddr;
+                TcpPort = port;
+                ServerAddr = serverAddr;
             }
             else
             {
                 m_UseSsl = useSsl;
 
                 if (!m_UseSsl)
-                    m_TcpPort = LeUnsecurePort;
+                    TcpPort = LeUnsecurePort;
                 else
-                    m_TcpPort = LeSecurePort;
+                    TcpPort = LeSecurePort;
 
-                m_ServerAddr = String.Format(LeDataUrl, region); // By default m_ServerAddr points to api.logentries.com if useDataHub is not set to true.
+                ServerAddr = String.Format(LeDataUrl, region); // By default m_ServerAddr points to api.logentries.com if useDataHub is not set to true.
             }
         }
 
         private bool m_UseSsl = false;
-        private int m_TcpPort;
+        public int TcpPort { get; private set; }
         private TcpClient m_Client = null;
         private Stream m_Stream = null;
         private SslStream m_SslStream = null;
-        private String m_ServerAddr = null;
+        public String ServerAddr { get; private set; }
 
         private Stream ActiveStream
         {
@@ -86,37 +83,55 @@ namespace InsightCore.Net
 
         public void Connect()
         {
-            m_Client = new TcpClient(m_ServerAddr, m_TcpPort);
+            m_Client = new TcpClient();
+#if NETSTANDARD1_3
+            m_Client.ConnectAsync(ServerAddr, TcpPort).Wait();
+#else
+            m_Client.Connect(ServerAddr, TcpPort);
+#endif
             m_Client.NoDelay = true;
 
             // on Azure sockets will be closed after some minutes idle.
             // which for some reason messes up this library causing it to lose data.
-            
+
             // turn on keepalive, to keep the sockets open.
             // I don't really understand why this helps the problem, since the socket already has NoDelay set
             // so data should be sent immediately. And indeed it does appear to be sent promptly when it works.
-            m_Client.Client.SetSocketOption( SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
+            m_Client.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
 
-            // set timeouts to 10 seconds idle before keepalive, 1 second between repeats, 
-            SetSocketKeepAliveValues(m_Client, 10 *1000, 1000);
-            
+            // set timeouts to 10 seconds idle before keepalive, 1 second between repeats,
+            try
+            {
+#if NETSTANDARD1_3
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    SetSocketKeepAliveValues(m_Client, 10 * 1000, 1000);
+                }
+#else
+                SetSocketKeepAliveValues(m_Client, 10 * 1000, 1000);
+#endif
+            }
+            catch (PlatformNotSupportedException)
+            {
+                // .net core on linux does not support modification of that settings at the moment. defaults applied.
+            }
+
             m_Stream = m_Client.GetStream();
 
             if (m_UseSsl)
             {
                 m_SslStream = new SslStream(m_Stream);
-                m_SslStream.AuthenticateAsClient(m_ServerAddr);
-
+#if NETSTANDARD1_3
+                m_SslStream.AuthenticateAsClientAsync(ServerAddr).Wait();
+#else
+                m_SslStream.AuthenticateAsClient(ServerAddr);
+#endif
             }
         }
 
         public void Write(byte[] buffer, int offset, int count)
         {
             ActiveStream.Write(buffer, offset, count);
-        }
-
-        public void Flush()
-        {
             ActiveStream.Flush();
         }
 
@@ -126,10 +141,16 @@ namespace InsightCore.Net
             {
                 try
                 {
-                    m_Client.Close();
+                    ((IDisposable)m_Client).Dispose();
                 }
                 catch
                 {
+                }
+                finally
+                {
+                    m_Client = null;
+                    m_Stream = null;
+                    m_SslStream = null;
                 }
             }
         }

--- a/src/R7InsightCore/Properties/AssemblyInfo.cs
+++ b/src/R7InsightCore/Properties/AssemblyInfo.cs
@@ -2,18 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("R7Insight.Core")]
-[assembly: AssemblyDescription("Rapid7 Insight logging core library for dotnet support")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Rapid7")]
-[assembly: AssemblyProduct("R7Insight.Core")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
@@ -21,16 +9,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("14055980-6937-4745-9449-dabf47c1d892")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.6.7.0")]
-[assembly: AssemblyFileVersion("2.6.7.0")]

--- a/src/R7InsightCore/R7Insight.Core.csproj
+++ b/src/R7InsightCore/R7Insight.Core.csproj
@@ -1,68 +1,38 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{90D6E9FC-7B88-4E1B-B018-8FA742274558}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>R7Insight.Core</RootNamespace>
-    <AssemblyName>R7Insight.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFrameworks>net35;net40;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
+
+    <PackageVersion>2.9.0</PackageVersion>
+    <Company>Rapid7</Company>
+    <Authors>Rapid7</Authors>
+    <Description>Rapid7 Insight logging core library for dotnet support. </Description>
+    <PackageReleaseNotes></PackageReleaseNotes>
+    <Copyright>Copyright © 2017</Copyright>
+    <PackageTags>Insight;logging</PackageTags>
+    <PackageLicenseUrl>https://github.com/rapid7/r7insight_dotnet/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/rapid7/r7insight_dotnet/</PackageProjectUrl>
+
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
     <Reference Include="System" />
-    <Reference Include="System.configuration" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="Microsoft.WindowsAzure.Configuration">
-      <HintPath>..\packages\Microsoft.WindowsAzure.ConfigurationManager.3.2.3\lib\net40\Microsoft.WindowsAzure.Configuration.dll</HintPath>
-    </Reference>
+    <Reference Include="System.Configuration" />
+    <PackageReference Include="TaskParallelLibrary" Version="1.0.2856.0" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="AsyncLogger.cs" />
-    <Compile Include="InsightClient.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.1.0" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
+    <PackageReference Include="System.Net.Security" Version="4.0.1" />
+    <PackageReference Include="System.Threading" Version="4.0.11" />
+    <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>if $(ConfigurationName) == Release (
-COPY "$(TargetPath)" "%25NUGET_PROJECTS%25$(ProjectName)\2.6.0\lib\net40\" /Y
-nuget pack %25NUGET_PROJECTS%25$(ProjectName)\2.6.0\r7insight.core.nuspec /o %25NUGET_PROJECTS%25$(ProjectName)\2.6.0\
-)</PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/src/R7InsightCore/SettingsLookup.cs
+++ b/src/R7InsightCore/SettingsLookup.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace InsightCore.Net
+{
+    public class SettingsLookup
+    {
+        public delegate string SettingLookupDelegate(string settingKey);
+
+        readonly List<KeyValuePair<string, SettingLookupDelegate>> SettingStores = new List<KeyValuePair<string, SettingLookupDelegate>>();
+
+        public string GetSettingValue(string settingKey, out string settingStoreName)
+        {
+            foreach (var settings in SettingStores)
+            {
+                try
+                {
+                    string settingValue = settings.Value.Invoke(settingKey);
+                    if (settingValue != null && !string.IsNullOrEmpty(settingValue.Trim()))
+                    {
+                        settingStoreName = settings.Key;
+                        return settingValue;
+                    }
+                }
+                catch
+                {
+                    // Setting store not available
+                }
+            }
+
+            settingStoreName = string.Empty;
+            return string.Empty;
+        }
+
+        public void RegisterSettingStore(string settingStoreName, SettingLookupDelegate lookup)
+        {
+            SettingStores.Insert(0, new KeyValuePair<string, SettingLookupDelegate>(settingStoreName, lookup));
+        }
+
+        public void ClearSettingStores()
+        {
+            SettingStores.Clear();
+        }
+    }
+}

--- a/src/R7InsightCore/SettingsLookupFactory.cs
+++ b/src/R7InsightCore/SettingsLookupFactory.cs
@@ -1,0 +1,46 @@
+﻿using System;
+#if !NETSTANDARD1_3
+using System.Configuration;
+#endif
+#if !NET35 && !NETSTANDARD1_3 && !NETSTANDARD2_0
+using Microsoft.Azure;
+#endif
+
+namespace InsightCore.Net
+{
+    static class SettingsLookupFactory
+    {
+        public static SettingsLookup Create()
+        {
+            SettingsLookup settingsLookup = new SettingsLookup();
+            settingsLookup.RegisterSettingStore("Environment Variable", CreateEnvironmentVariableLookup());
+#if !NETSTANDARD1_3 && !NETSTANDARD2_0
+            settingsLookup.RegisterSettingStore("App Settings", CreateAppSettingsLookup());
+#endif
+#if !NET35 && !NETSTANDARD1_3 && !NETSTANDARD2_0
+            if (Environment.OSVersion.Platform != PlatformID.Unix && Type.GetType("Mono.Runtime") != null)
+                settingsLookup.RegisterSettingStore("Cloud Configuration", CreateCloudConfigurationManagerLookup());
+#endif
+            return settingsLookup;
+        }
+
+        static SettingsLookup.SettingLookupDelegate CreateEnvironmentVariableLookup()
+        {
+            return new SettingsLookup.SettingLookupDelegate((settingKey) => System.Environment.GetEnvironmentVariable(settingKey));
+        }
+
+#if !NETSTANDARD1_3 && !NETSTANDARD2_0
+        static SettingsLookup.SettingLookupDelegate CreateAppSettingsLookup()
+        {
+            return new SettingsLookup.SettingLookupDelegate((settingKey) => ConfigurationManager.AppSettings.Get(settingKey));
+        }
+#endif
+
+#if !NET35 && !NETSTANDARD1_3 && !NETSTANDARD2_0
+        static SettingsLookup.SettingLookupDelegate CreateCloudConfigurationManagerLookup()
+        {
+            return new SettingsLookup.SettingLookupDelegate((settingKey) => CloudConfigurationManager.GetSetting(settingKey));
+        }
+#endif
+    }
+}

--- a/src/R7InsightCore/packages.config
+++ b/src/R7InsightCore/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Microsoft.WindowsAzure.ConfigurationManager" version="3.2.3" targetFramework="net40" />
-</packages>

--- a/src/R7InsightLog4net/InsightAppender.cs
+++ b/src/R7InsightLog4net/InsightAppender.cs
@@ -24,7 +24,7 @@ namespace log4net.Appender
                 bool success = base.LoadCredentials();
                 if (!success)
                 {
-                    log4net.Util.LogLog.Warn(GetType(), "Failed to load credentials for LogEntries (GET), please check LOGENTRIES_TOKEN configuration");
+                    log4net.Util.LogLog.Warn(GetType(), "Failed to load credentials");
                 }
                 return success;
             }

--- a/src/R7InsightLog4net/Properties/AssemblyInfo.cs
+++ b/src/R7InsightLog4net/Properties/AssemblyInfo.cs
@@ -2,18 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("R7Insight.Log4net")]
-[assembly: AssemblyDescription("Rapid7 Insight logging support log4net library")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Rapid7")]
-[assembly: AssemblyProduct("R7Insight.Log4net")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
@@ -21,16 +9,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("44fdf6b1-1918-4af1-814c-da387736b675")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.6.2.0")]
-[assembly: AssemblyFileVersion("2.6.2.0")]

--- a/src/R7InsightLog4net/R7Insight.Log4net.csproj
+++ b/src/R7InsightLog4net/R7Insight.Log4net.csproj
@@ -1,72 +1,27 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{CF8A9166-3B7D-4D4C-82CB-6C98C68DB110}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>R7Insight.Log4net</RootNamespace>
-    <AssemblyName>R7Insight.Log4net</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFrameworks>net35;net40;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
+
+    <PackageVersion>2.9.0</PackageVersion>
+    <Authors>Rapid7</Authors>
+    <Company>Rapid7</Company>
+    <Description>Rapid7 Insight logging support log4net library</Description>
+    <PackageReleaseNotes></PackageReleaseNotes>
+    <Copyright>Copyright © 2017</Copyright>
+    <PackageTags>log4net;Insight;logging</PackageTags>
+    <PackageLicenseUrl>https://github.com/rapid7/r7insight_dotnet/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/rapid7/r7insight_dotnet/</PackageProjectUrl>
+
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="log4net">
-      <HintPath>..\packages\log4net.2.0.8\lib\net40-full\log4net.dll</HintPath>
-    </Reference>
+    <PackageReference Include="log4net" Version="2.0.8" />
   </ItemGroup>
+
   <ItemGroup>
-    <Compile Include="InsightAppender.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+    <ProjectReference Include="..\R7InsightCore\R7Insight.Core.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\R7InsightCore\R7Insight.Core.csproj">
-      <Project>{90D6E9FC-7B88-4E1B-B018-8FA742274558}</Project>
-      <Name>R7Insight.Core</Name>
-    </ProjectReference>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>if $(ConfigurationName) == Release (
-COPY "$(TargetPath)" "%25NUGET_PROJECTS%25$(ProjectName)\2.5.0\lib\net40\" /Y
-nuget pack %25NUGET_PROJECTS%25$(ProjectName)\2.5.0\logentries.log4net.nuspec /o %25NUGET_PROJECTS%25$(ProjectName)\2.5.0\
-)</PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
 </Project>

--- a/src/R7InsightLog4net/packages.config
+++ b/src/R7InsightLog4net/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="log4net" version="2.0.8" targetFramework="net40" />
-</packages>

--- a/src/R7InsightNLog/InsightTarget.cs
+++ b/src/R7InsightNLog/InsightTarget.cs
@@ -13,115 +13,141 @@ using InsightCore.Net;
 namespace NLog.Targets
 {
     [Target("Insight")]
-    public sealed class InsightTarget : TargetWithLayout
+    public sealed class InsightTarget : TargetWithLayout, IAsyncLoggerConfig
     {
-        private AsyncLogger insightAsync;
+        class NLogAsyncLogger : AsyncLogger
+        {
+            protected override void WriteDebugMessages(string message, Exception ex)
+            {
+                base.WriteDebugMessages(message, ex);
+                InternalLogger.Warn(string.Concat(message, " Exception: ", ex.ToString()));
+            }
+
+            public override bool LoadCredentials()
+            {
+                bool success = base.LoadCredentials();
+                if (!success)
+                {
+                    InternalLogger.Warn("Failed to load credentials for LogEntries (GET), please check LOGENTRIES_TOKEN configuration");
+                }
+                return success;
+            }
+        }
+
+        private NLogAsyncLogger insightAsync;
 
         public InsightTarget()
         {
-            insightAsync = new AsyncLogger();
+            insightAsync = new NLogAsyncLogger();
         }
 
-        
-        /** Debug flag. */
+        /// <inheritdoc />
         public bool Debug 
         {
             get { return insightAsync.getDebug(); }
             set { insightAsync.setDebug(value); } 
         }
 
-        /** Is using DataHub parameter flag. - ste to true if it is needed to send messages to DataHub instance. */
+        /// <inheritdoc />
         public bool IsUsingDataHub
         {
             get { return insightAsync.getIsUsingDataHab(); }
             set { insightAsync.setIsUsingDataHub(value); }
         }
 
-        /** DataHub server address */
-        public String DataHubAddr
+        /// <inheritdoc />
+        public string DataHubAddress
         {
             get { return insightAsync.getDataHubAddr(); }
             set { insightAsync.setDataHubAddr(value); }
         }
 
-        /** DataHub server port */
+        /// <inheritdoc />
         public int DataHubPort
         {
             get { return insightAsync.getDataHubPort(); }
             set { insightAsync.setDataHubPort(value); }
         }
 
-        /** Option to set Token programmatically or in Appender Definition */
+        /// <inheritdoc />
+        public bool UseSsl
+        {
+            get { return insightAsync.getUseSsl(); }
+            set { insightAsync.setUseSsl(value); }
+        }
+
+        /// <inheritdoc />
         public string Token
         {
             get { return insightAsync.getToken(); }
             set { insightAsync.setToken(value); }
         }
 
-        /** SSL/TLS parameter flag */
-        public bool Ssl
-        {
-            get { return insightAsync.getUseSsl(); }
-            set { insightAsync.setUseSsl(value); }
-        }
-
-        /** ACCOUNT_KEY parameter for HTTP PUT logging */
-        public String Key
-        {
-            get { return insightAsync.getAccountKey(); }
-            set { insightAsync.setAccountKey(value); }
-        }
-
-        /** LOCATION parameter for HTTP PUT logging */
-        public String Location
-        {
-            get { return insightAsync.getLocation(); }
-            set { insightAsync.setLocation(value); }
-        }
-
-        /* LogHostname - switch that defines whether add host name to the log message */
+        /// <inheritdoc />
         public bool LogHostname
         {
             get { return insightAsync.getUseHostName(); }
             set { insightAsync.setUseHostName(value); }
         }
 
-        /* HostName - user-defined host name. If empty the library will try to obtain it automatically */
-        public String HostName
+        /// <inheritdoc />
+        public string HostName
         {
             get { return insightAsync.getHostName(); }
             set { insightAsync.setHostName(value); }
         }
 
-        /* User-defined log message ID */
-        public String LogID
+        /// <inheritdoc />
+        public string LogID
         {
             get { return insightAsync.getLogID(); }
             set { insightAsync.setLogID(value); }
         }
 
-        /* User-defined log message ID */
-        public String Region
+        /// <inheritdoc />
+        public string Region
         {
             get { return insightAsync.getRegion(); }
             set { insightAsync.setRegion(value); }
         }
 
-        public bool KeepConnection { get; set; }
-
         protected override void Write(LogEventInfo logEvent)
         {
             //Render message content
             String renderedEvent = this.Layout.Render(logEvent);
-
             insightAsync.AddLine(renderedEvent);
         }
 
         protected override void CloseTarget()
         {
             base.CloseTarget();
-
             insightAsync.interruptWorker();
+        }
+
+        protected override void FlushAsync(AsyncContinuation asyncContinuation)
+        {
+            if (!insightAsync.FlushQueue(TimeSpan.FromMilliseconds(50)))
+            {
+                System.Threading.Tasks.Task.Factory.StartNew(() =>
+                {
+                    for (int i = 0; i < 3; ++i)
+                    {
+                        InternalLogger.Trace("Waiting for AsyncLogger queue flush");
+                        if (insightAsync.FlushQueue(TimeSpan.FromSeconds(5)))
+                        {
+                            InternalLogger.Trace("Completed AsyncLogger queue flush");
+                            asyncContinuation(null);
+                            return;
+                        }
+                    }
+                    InternalLogger.Warn("Timeout while waiting for AsyncLogger queue flush");
+                    asyncContinuation(new TimeoutException("AsyncLogger queues are not empty"));
+                }, System.Threading.CancellationToken.None, System.Threading.Tasks.TaskCreationOptions.None, System.Threading.Tasks.TaskScheduler.Default);
+            }
+            else
+            {
+                asyncContinuation(null);
+            }
         }
     }
 }

--- a/src/R7InsightNLog/InsightTarget.cs
+++ b/src/R7InsightNLog/InsightTarget.cs
@@ -28,7 +28,7 @@ namespace NLog.Targets
                 bool success = base.LoadCredentials();
                 if (!success)
                 {
-                    InternalLogger.Warn("Failed to load credentials for LogEntries (GET), please check LOGENTRIES_TOKEN configuration");
+                    InternalLogger.Warn("Failed to load credentials");
                 }
                 return success;
             }

--- a/src/R7InsightNLog/Properties/AssemblyInfo.cs
+++ b/src/R7InsightNLog/Properties/AssemblyInfo.cs
@@ -2,18 +2,6 @@
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-// General Information about an assembly is controlled through the following 
-// set of attributes. Change these attribute values to modify the information
-// associated with an assembly.
-[assembly: AssemblyTitle("R7Insight.NLog")]
-[assembly: AssemblyDescription("Rapid7 Insight logging support nlog library")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Rapid7")]
-[assembly: AssemblyProduct("R7Insight.NLog")]
-[assembly: AssemblyCopyright("Copyright ©  2017")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
 // Setting ComVisible to false makes the types in this assembly not visible 
 // to COM components.  If you need to access a type in this assembly from 
 // COM, set the ComVisible attribute to true on that type.
@@ -21,16 +9,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("7e04ff2d-ea59-4b62-969d-72bd3e37c684")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.4.5.0")]
-[assembly: AssemblyFileVersion("2.4.5.0")]

--- a/src/R7InsightNLog/R7Insight.NLog.csproj
+++ b/src/R7InsightNLog/R7Insight.NLog.csproj
@@ -1,73 +1,39 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{9DC31DE3-79FF-47A8-96B4-6BA18F6BB1CB}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>R7Insight.NLog</RootNamespace>
-    <AssemblyName>R7Insight.NLog</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
+    <TargetFrameworks>net35;net40;netstandard1.3;netstandard2.0</TargetFrameworks>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
+
+    <PackageVersion>2.9.0</PackageVersion>
+    <Authors>Rapid7</Authors>
+    <Company>Rapid7</Company>
+    <Description>Rapid7 Insight logging support nlog library</Description>
+    <PackageReleaseNotes></PackageReleaseNotes>
+    <Copyright>Copyright © 2017</Copyright>
+    <PackageTags>nlog;Insight;logging</PackageTags>
+    <PackageLicenseUrl>https://github.com/rapid7/r7insight_dotnet/blob/master/LICENSE.txt</PackageLicenseUrl>
+    <PackageProjectUrl>https://github.com/rapid7/r7insight_dotnet/</PackageProjectUrl>
+
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>
-    </DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="NLog">
-      <HintPath>..\packages\NLog.4.4.10\lib\net40\NLog.dll</HintPath>
-    </Reference>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
+    <PackageReference Include="NLog" Version="4.4.10" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="InsightTarget.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+    <PackageReference Include="NLog" Version="4.4.10" />
   </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\R7InsightCore\R7Insight.Core.csproj">
-      <Project>{90D6E9FC-7B88-4E1B-B018-8FA742274558}</Project>
-      <Name>R7Insight.Core</Name>
-    </ProjectReference>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="NLog" Version="4.5.0" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="NLog" Version="4.5.0" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>if $(ConfigurationName) == Release (
-COPY "$(TargetPath)" "%25NUGET_PROJECTS%25$(ProjectName)\2.3.0\lib\net40\" /Y
-nuget pack %25NUGET_PROJECTS%25$(ProjectName)\2.3.0\insight.nlog.nuspec /o %25NUGET_PROJECTS%25$(ProjectName)\2.3.0\
-)</PostBuildEvent>
-  </PropertyGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
+  <ItemGroup>
+    <ProjectReference Include="..\R7InsightCore\R7Insight.Core.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/R7InsightNLog/packages.config
+++ b/src/R7InsightNLog/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NLog" version="4.4.10" targetFramework="net40" />
-</packages>


### PR DESCRIPTION
- Removed obsolete HTTP-PUT stuff.
- Introduced SettingsLookupFactory that creates a default SettingsLookup-store (Allow NetStandard1_3 to provides its own setting-lookup-mechanism).
- Changed Thread.Abort/Interrupt into a standard CancellationTokenSource.
- Added support for very large log-messages (Just like in the Java-version) (Fixes #30)
- Fixed bug in handling of token-based-input, where prefix was inject before the token (Now it is like the Java-version)
- Optimized finalLine to be a StringBuilder (Just like in the Java-version)
- Optimized `WriteDebugMessages<T>` to be non-allocating when debug is disabled (And fixes bug where exceptions were not written)
- Extended the NLog-Target and Log4net-Appender to automatically support Flush, so special shutdown-flush-logic is not needed.
- Extended exception logging, so it is also forwarded to the log-framework specific diagnostic-logging.
- Support "restart" of the AsyncLogger-thread, as NLog-target will close and re-initialize on configuration reload.

Fixed the nuget-packages so `R7Insight.NLog` has correct dependency on `R7Insight.Core`.

Just need to write the following to create the nuget-packages:

`msbuild .\src /t:restore,pack /p:configuration=Release /p:PackageOutputPath=.\..\..\artifacts`