### PR TITLE
Fix OutOfRangeException when input string is bigger then LOG_LENGTH_LIMIT

### DIFF
--- a/src/R7InsightCore/AsyncLogger.cs
+++ b/src/R7InsightCore/AsyncLogger.cs
@@ -652,7 +652,7 @@ namespace InsightCore.Net
                     Queue.TryAdd(trimmedEvent);
                 }
 
-                AddLineToQueue(trimmedEvent.Substring(LOG_LENGTH_LIMIT, trimmedEvent.Length), limit - 1);
+                AddLineToQueue(trimmedEvent.Substring(LOG_LENGTH_LIMIT, trimmedEvent.Length - LOG_LENGTH_LIMIT), limit - 1);
             }
             else
             {

--- a/src/R7InsightCore/AsyncLogger.cs
+++ b/src/R7InsightCore/AsyncLogger.cs
@@ -652,7 +652,7 @@ namespace InsightCore.Net
                     Queue.TryAdd(trimmedEvent);
                 }
 
-                AddLineToQueue(trimmedEvent.Substring(LOG_LENGTH_LIMIT, trimmedEvent.Length - LOG_LENGTH_LIMIT), limit - 1);
+                AddLineToQueue(trimmedEvent.Substring(LOG_LENGTH_LIMIT), limit - 1);
             }
             else
             {


### PR DESCRIPTION
This PR fix a bug when the input string to the method AddLineToQueue its bigger then LOG_LENGTH_LIMIT, and will be sent in multiple lines.
string.Substring() second parameter is the number of characters to read, not the index in the original string.

at System.ArgumentOutOfRangeException: Index and length must refer to a location within the string. (Parameter 'length')\r\n
at System.String.Substring(Int32 startIndex, Int32 length)\r\n   at InsightCore.Net.AsyncLogger.AddLineToQueue(String line, Int32 limit)\r\n
at InsightCore.Net.AsyncLogger.AddLine(String line)