### PR TITLE
LOG-21638 Security fixes

### DIFF
--- a/src/R7InsightCore/AsyncLogger.cs
+++ b/src/R7InsightCore/AsyncLogger.cs
@@ -262,15 +262,7 @@ namespace InsightCore.Net
                             WriteDebugMessages("HostName parameter is not defined - trying to get it from System.Environment.MachineName");
 
                             string hostName;
-#if NETSTANDARD1_3
-                            hostName = System.Environment.GetEnvironmentVariable("COMPUTERNAME") ?? string.Empty;
-                            if (string.IsNullOrEmpty(hostName))
-                                hostName = System.Environment.GetEnvironmentVariable("HOSTNAME") ?? string.Empty;
-                            if (string.IsNullOrEmpty(hostName))
-                                throw new ArgumentNullException("HOSTNAME");
-#else
                             hostName = System.Environment.MachineName;
-#endif
                             m_HostName = "HostName=" + hostName + " ";
                         }
                         catch (Exception ex)
@@ -517,12 +509,8 @@ namespace InsightCore.Net
 
             try
             {
-#if NET35
-                newGuid = new Guid(guidString);
-#else
                 if (!System.Guid.TryParse(guidString, out newGuid))
                     return false;
-#endif
                 return newGuid != System.Guid.Empty;
             }
             catch

--- a/src/R7InsightCore/InsightClient.cs
+++ b/src/R7InsightCore/InsightClient.cs
@@ -9,7 +9,7 @@ namespace InsightCore.Net
     class InsightClient
     {
         // Rapid7 Insight API server address. 
-        protected const String LeDataUrl = "{0}.data.logs.insight.rapid7.com";
+        protected const string LeDataUrl = "{0}.data.logs.insight.rapid7.com";
 
         // Port number for logging on Rapid7 Insight DATA server. 
         protected const int LeUnsecurePort = 80;
@@ -17,11 +17,8 @@ namespace InsightCore.Net
         // Port number for SSL logging on Rapid7 Insight DATA server. 
         protected const int LeSecurePort = 443;
 
-        // Creates InsightClient instance. If do not define useServerUrl and/or useOverrideProt during call
-        // will be configured to work with the defined server on defined port.
-        public InsightClient(bool useSsl, bool useDataHub, String serverAddr, int port, String region)
+        public InsightClient(bool useSsl, bool useDataHub, string serverAddr, int port, string region)
         {
-            // Override port number and server address to send logs to DataHub instance.
             if (useDataHub)
             {
                 m_UseSsl = false; // DataHub does not support receiving log messages over SSL for now.
@@ -31,13 +28,8 @@ namespace InsightCore.Net
             else
             {
                 m_UseSsl = useSsl;
-
-                if (!m_UseSsl)
-                    TcpPort = LeUnsecurePort;
-                else
-                    TcpPort = LeSecurePort;
-
-                ServerAddr = String.Format(LeDataUrl, region);
+                TcpPort = m_UseSsl ? LeSecurePort : LeUnsecurePort;
+                ServerAddr = string.Format(LeDataUrl, region);
             }
         }
 
@@ -46,72 +38,38 @@ namespace InsightCore.Net
         private TcpClient m_Client = null;
         private Stream m_Stream = null;
         private SslStream m_SslStream = null;
-        public String ServerAddr { get; private set; }
+        public string ServerAddr { get; private set; }
 
-        private Stream ActiveStream
+        private Stream ActiveStream => m_UseSsl ? m_SslStream : m_Stream;
+
+        public void SetSocketKeepAliveValues(TcpClient tcpc, int keepAliveTime, int keepAliveInterval)
         {
-            get
-            {
-                return m_UseSsl ? m_SslStream : m_Stream;
-            }
-        }
+            uint dummy = 0;
+            byte[] inOptionValues = new byte[Marshal.SizeOf(dummy) * 3];
+            bool onOff = true;
 
-        public void SetSocketKeepAliveValues(TcpClient tcpc, int KeepAliveTime, int KeepAliveInterval)
-        {
-            //KeepAliveTime: default value is 2hr
-            //KeepAliveInterval: default value is 1s and Detect 5 times
+            BitConverter.GetBytes((uint)(onOff ? 1 : 0)).CopyTo(inOptionValues, 0);
+            BitConverter.GetBytes((uint)keepAliveTime).CopyTo(inOptionValues, Marshal.SizeOf(dummy));
+            BitConverter.GetBytes((uint)keepAliveInterval).CopyTo(inOptionValues, Marshal.SizeOf(dummy) * 2);
 
-            uint dummy = 0; //lenth = 4
-            byte[] inOptionValues = new byte[System.Runtime.InteropServices.Marshal.SizeOf(dummy) * 3]; //size = lenth * 3 = 12
-            bool OnOff = true;
-
-            BitConverter.GetBytes((uint)(OnOff ? 1 : 0)).CopyTo(inOptionValues, 0);
-            BitConverter.GetBytes((uint)KeepAliveTime).CopyTo(inOptionValues, Marshal.SizeOf(dummy));
-            BitConverter.GetBytes((uint)KeepAliveInterval).CopyTo(inOptionValues, Marshal.SizeOf(dummy) * 2);
-            // of course there are other ways to marshal up this byte array, this is just one way
-            // call WSAIoctl via IOControl
-
-            // .net 1.1 type
-            //int SIO_KEEPALIVE_VALS = -1744830460; //(or 0x98000004)
-            //socket.IOControl(SIO_KEEPALIVE_VALS, inOptionValues, null); 
-
-            // .net 3.5 type
             tcpc.Client.IOControl(IOControlCode.KeepAliveValues, inOptionValues, null);
         }
 
         public void Connect()
         {
             m_Client = new TcpClient();
-#if NETSTANDARD1_3
-            m_Client.ConnectAsync(ServerAddr, TcpPort).Wait();
-#else
             m_Client.Connect(ServerAddr, TcpPort);
-#endif
             m_Client.NoDelay = true;
 
-            // on Azure sockets will be closed after some minutes idle.
-            // which for some reason messes up this library causing it to lose data.
-
-            // turn on keepalive, to keep the sockets open.
-            // I don't really understand why this helps the problem, since the socket already has NoDelay set
-            // so data should be sent immediately. And indeed it does appear to be sent promptly when it works.
             m_Client.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.KeepAlive, true);
 
-            // set timeouts to 10 seconds idle before keepalive, 1 second between repeats,
             try
             {
-#if NETSTANDARD1_3
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    SetSocketKeepAliveValues(m_Client, 10 * 1000, 1000);
-                }
-#else
                 SetSocketKeepAliveValues(m_Client, 10 * 1000, 1000);
-#endif
             }
             catch (PlatformNotSupportedException)
             {
-                // .net core on linux does not support modification of that settings at the moment. defaults applied.
+                // .NET on Linux does not support modification of that settings at the moment. Defaults applied.
             }
 
             m_Stream = m_Client.GetStream();
@@ -119,11 +77,7 @@ namespace InsightCore.Net
             if (m_UseSsl)
             {
                 m_SslStream = new SslStream(m_Stream);
-#if NETSTANDARD1_3
-                m_SslStream.AuthenticateAsClientAsync(ServerAddr).Wait();
-#else
                 m_SslStream.AuthenticateAsClient(ServerAddr);
-#endif
             }
         }
 
@@ -139,7 +93,7 @@ namespace InsightCore.Net
             {
                 try
                 {
-                    ((IDisposable)m_Client).Dispose();
+                    m_Client.Dispose();
                 }
                 catch
                 {

--- a/src/R7InsightCore/R7Insight.Core.csproj
+++ b/src/R7InsightCore/R7Insight.Core.csproj
@@ -1,14 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
-
-    <PackageVersion>2.9.2</PackageVersion>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>3.0.0</PackageVersion>
     <Company>Rapid7</Company>
     <Authors>Rapid7</Authors>
-    <Description>Rapid7 Insight logging core library for dotnet support. </Description>
-    <PackageReleaseNotes>Fix typo</PackageReleaseNotes>
+    <Description>Rapid7 Insight logging core library for dotnet support.</Description>
+    <PackageReleaseNotes>Bump dependencies for vulnerabilities</PackageReleaseNotes>
     <Copyright>Copyright © 2020</Copyright>
     <PackageTags>Insight;logging;logger;insightops;rapid7</PackageTags>
     <PackageLicense>https://github.com/rapid7/r7insight_dotnet/blob/master/LICENSE.txt</PackageLicense>
@@ -22,23 +20,9 @@
     <PackageId>R7Insight.Core</PackageId>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <PackageReference Include="TaskParallelLibrary" Version="1.0.2856.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="System.Configuration" />
-    <PackageReference Include="Microsoft.WindowsAzure.ConfigurationManager" Version="3.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.0.0" />
-    <PackageReference Include="System.Net.Security" Version="4.0.1" />
-    <PackageReference Include="System.Threading" Version="4.0.11" />
-    <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
+  <ItemGroup>
+    <PackageReference Include="System.Net.Security" Version="4.3.2" />
+    <PackageReference Include="log4net" Version="2.0.17" />
   </ItemGroup>
 
 </Project>

--- a/src/R7InsightCore/SettingsLookupFactory.cs
+++ b/src/R7InsightCore/SettingsLookupFactory.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-#if !NETSTANDARD1_3
 using System.Configuration;
-#endif
-#if !NET35 && !NETSTANDARD1_3 && !NETSTANDARD2_0
-using Microsoft.Azure;
-#endif
 
 namespace InsightCore.Net
 {
@@ -14,13 +9,7 @@ namespace InsightCore.Net
         {
             SettingsLookup settingsLookup = new SettingsLookup();
             settingsLookup.RegisterSettingStore("Environment Variable", CreateEnvironmentVariableLookup());
-#if !NETSTANDARD1_3 && !NETSTANDARD2_0
             settingsLookup.RegisterSettingStore("App Settings", CreateAppSettingsLookup());
-#endif
-#if !NET35 && !NETSTANDARD1_3 && !NETSTANDARD2_0
-            if (Environment.OSVersion.Platform != PlatformID.Unix && Type.GetType("Mono.Runtime") != null)
-                settingsLookup.RegisterSettingStore("Cloud Configuration", CreateCloudConfigurationManagerLookup());
-#endif
             return settingsLookup;
         }
 
@@ -29,18 +18,9 @@ namespace InsightCore.Net
             return new SettingsLookup.SettingLookupDelegate((settingKey) => System.Environment.GetEnvironmentVariable(settingKey));
         }
 
-#if !NETSTANDARD1_3 && !NETSTANDARD2_0
         static SettingsLookup.SettingLookupDelegate CreateAppSettingsLookup()
         {
             return new SettingsLookup.SettingLookupDelegate((settingKey) => ConfigurationManager.AppSettings.Get(settingKey));
         }
-#endif
-
-#if !NET35 && !NETSTANDARD1_3 && !NETSTANDARD2_0
-        static SettingsLookup.SettingLookupDelegate CreateCloudConfigurationManagerLookup()
-        {
-            return new SettingsLookup.SettingLookupDelegate((settingKey) => CloudConfigurationManager.GetSetting(settingKey));
-        }
-#endif
     }
 }

--- a/src/R7InsightLog4net/R7Insight.Log4net.csproj
+++ b/src/R7InsightLog4net/R7Insight.Log4net.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
-
-    <PackageVersion>2.9.2</PackageVersion>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>3.0.0</PackageVersion>
     <Authors>Rapid7</Authors>
     <Company>Rapid7</Company>
     <Description>Rapid7 Insight logging support log4net library</Description>
@@ -12,17 +10,16 @@
     <PackageTags>log4net;Insight;logging;rapid7;logger</PackageTags>
     <PackageLicense>https://github.com/rapid7/r7insight_dotnet/blob/master/LICENSE.txt</PackageLicense>
     <PackageProjectUrl>https://github.com/rapid7/r7insight_dotnet/</PackageProjectUrl>
-
     <NeutralLanguage>en</NeutralLanguage>
     <Owners>Rapid7</Owners>
     <Title>R7Insight.Log4net</Title>
     <Summary>Rapid7 Insight logging support log4net library</Summary>
-    <PackageReleaseNotes>Fix typo</PackageReleaseNotes>
+    <PackageReleaseNotes>Bump dependencies for vulnerabilities</PackageReleaseNotes>
     <PackOnBuild>true</PackOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="log4net" Version="2.0.10" />
+    <PackageReference Include="log4net" Version="2.0.17" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/R7InsightNLog/R7Insight.NLog.csproj
+++ b/src/R7InsightNLog/R7Insight.NLog.csproj
@@ -1,10 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net40;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.3' ">1.6.0</NetStandardImplicitPackageVersion>
-
-    <PackageVersion>2.9.2</PackageVersion>
+    <TargetFrameworks>net8.0;netstandard2.0</TargetFrameworks>
+    <PackageVersion>3.0.0</PackageVersion>
     <Authors>Rapid7</Authors>
     <Company>Rapid7</Company>
     <Description>Rapid7 Insight logging support nlog library</Description>
@@ -12,29 +10,17 @@
     <PackageTags>nlog;Insight;logging;logger;rapid7</PackageTags>
     <PackageLicense>https://github.com/rapid7/r7insight_dotnet/blob/master/LICENSE.txt</PackageLicense>
     <PackageProjectUrl>https://github.com/rapid7/r7insight_dotnet/</PackageProjectUrl>
-
     <NeutralLanguage>en</NeutralLanguage>
     <Owners>Rapid7</Owners>
     <Summary>Rapid7 Insight logging support nlog library</Summary>
     <Title>R7Insight.NLog</Title>
-    <PackageReleaseNotes>Fix typo</PackageReleaseNotes>
+    <PackageReleaseNotes>Bump dependencies for vulnerabilities</PackageReleaseNotes>
     <PackOnBuild>true</PackOnBuild>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <PackageReference Include="NLog" Version="4.4.10" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <PackageReference Include="NLog" Version="4.4.10" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="NLog" Version="4.5.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <PackageReference Include="NLog" Version="4.5.0" />
+  <ItemGroup>
+    <PackageReference Include="NLog" Version="4.7.15" />
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
builds and i've used this locally to smoke-test sending logs up to insightops

TL;DR:
1.drop support for a bunch of .net versions, from my limited research .net8 and netstandard2 are the reasonable ones to support
2. bump versions of libraries to not have security vulnerabilities
3. bump major
5. remove directives related to old versions